### PR TITLE
Add executor independent concurrency primitives

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,18 +11,22 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install Miri
+      run: |
+        rustup toolchain install nightly --component miri
+        cargo +nightly miri setup
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run Miri on sync
+      run: cargo +nightly miri test -p dot15d4 sync
 
   clippy:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/dot15d4/Cargo.toml
+++ b/dot15d4/Cargo.toml
@@ -12,6 +12,7 @@ tracing = { version = "0.1.38", default-features = false }
 bitflags = "2.4.2"
 heapless = "0.8.0"
 critical-section = "1.1"
+pollster = "0.3"
 
 colored = { version = "2", optional = true }
 clap = { version = "4.5.1", features = ["derive"], optional = true }

--- a/dot15d4/src/lib.rs
+++ b/dot15d4/src/lib.rs
@@ -3,5 +3,6 @@
 pub mod csma;
 pub mod frame;
 pub mod phy;
+pub mod sync;
 pub mod time;
 pub mod tsch;

--- a/dot15d4/src/sync/channel.rs
+++ b/dot15d4/src/sync/channel.rs
@@ -1,0 +1,173 @@
+#![no_std]
+//! Simple oneshot Channel implementation based on the one described in the book
+//! of Mara Bos, but adapted to work as a signaling mechanism. Sending will
+//! remain non-blocking and just overwrite the previous message.
+use core::cell::RefCell;
+use core::cell::UnsafeCell;
+use core::future::poll_fn;
+use core::future::Future;
+use core::mem::MaybeUninit;
+use core::pin::Pin;
+use core::task::Context;
+use core::task::Poll;
+use core::task::Waker;
+
+struct ChannelState {
+    is_ready: bool, // We always stay in the same task/thread -> no atomic needed here
+    waker: Option<Waker>,
+}
+
+pub struct Channel<T> {
+    message: UnsafeCell<MaybeUninit<T>>,
+    state: UnsafeCell<ChannelState>,
+}
+
+impl<T> Channel<T> {
+    pub fn new() -> Self {
+        Self {
+            message: UnsafeCell::new(MaybeUninit::uninit()),
+            state: UnsafeCell::new(ChannelState {
+                is_ready: false,
+                waker: None,
+            }),
+        }
+    }
+
+    pub fn split(&mut self) -> (Sender<'_, T>, Receiver<'_, T>) {
+        *self = Self::new(); // Drop previous channel to reset state. We have exclusive access here
+        (Sender { channel: self }, Receiver { channel: self })
+    }
+}
+
+pub struct Sender<'a, T> {
+    channel: &'a Channel<T>,
+}
+
+impl<T> Sender<'_, T> {
+    /// Sends a message across the channel. Sending multiple messages before the
+    /// Receiver can read them, results in overwriting the previous messages.
+    /// Only the last one will be actually sent. This method returns whether or
+    /// not the previous message was overwritten
+    pub fn send(&mut self, message: T) -> bool {
+        // If the channel is ready, make the message drop
+        // Safety: The state is only accessed inside a function body and never across an await point. No concurrent access here (same task)
+        let mut state = unsafe { &mut *self.channel.state.get() };
+        let did_replace = if state.is_ready {
+            unsafe {
+                // Drop previous message
+                // Safety: This is ok, as we are the only ones with access to the
+                // Sender and there is no concurrent access from the reader
+                let maybe_uninit = &mut *self.channel.message.get();
+                core::ptr::drop_in_place(maybe_uninit.as_mut_ptr());
+
+                // Store the new message
+                maybe_uninit.as_mut_ptr().write(message);
+                // The channel is already set to be ready -> keep it this way
+            }
+
+            // Wake the Receiver task
+            if let Some(waker) = state.waker.take() {
+                waker.wake()
+            }
+
+            // Signal that the channel has replaced something
+            true
+        } else {
+            // The channel is not yet ready -> store the message and make it ready
+            // Safety: We are the only one with access to the Sender and no concurrent access with the Receiver possible
+            unsafe {
+                let maybe_uninit = &mut *self.channel.message.get();
+                maybe_uninit.as_mut_ptr().write(message);
+            }
+
+            // Signal that the channel was empty before
+            false
+        };
+        // Wake the Receiver task
+        state.is_ready = true;
+        if let Some(waker) = state.waker.take() {
+            waker.wake()
+        }
+
+        // Did we replace the inner message or not
+        did_replace
+    }
+}
+
+pub struct Receiver<'a, T> {
+    channel: &'a Channel<T>,
+}
+
+impl<T> Receiver<'_, T> {
+    pub async fn receive(&mut self) -> T {
+        poll_fn(|cx| {
+            // Safety: We only access the state in the bounds of this call and never across an await point
+            let state = unsafe { &mut *self.channel.state.get() };
+
+            if !state.is_ready {
+                // Not yet ready, store/replace the context
+                match &mut state.waker {
+                    Some(waker) => waker.clone_from(cx.waker()),
+                    waker @ None => *waker = Some(cx.waker().clone()),
+                }
+
+                Poll::Pending
+            } else {
+                // Safety: We have a message, and exclusive access to the channel as there is no concurrent access possible
+                let message = unsafe {
+                    let maybe_uninit = &mut *self.channel.message.get();
+                    maybe_uninit.assume_init_read()
+                };
+                // Reset the state, such that we can send again
+                state.is_ready = false;
+
+                Poll::Ready(message)
+            }
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pollster::FutureExt as _;
+
+    use crate::sync::{join::join, select::select, yield_now::yield_now};
+
+    use super::Channel;
+
+    #[test]
+    pub fn test_channel_no_concurrency() {
+        async {
+            let mut channel = Channel::new();
+            let (mut send, mut recv) = channel.split();
+            send.send(1);
+            assert_eq!(recv.receive().await, 1);
+        }
+        .block_on();
+    }
+
+    #[test]
+    pub fn test_channel_join_concurrency() {
+        async {
+            let mut channel = Channel::new();
+            let (mut send, mut recv) = channel.split();
+
+            join(
+                async {
+                    for i in 0..10 {
+                        send.send(i);
+                        yield_now().await;
+                    }
+                },
+                async {
+                    for i in 0..10 {
+                        assert_eq!(recv.receive().await, i);
+                    }
+                },
+            )
+            .await;
+        }
+        .block_on();
+    }
+}

--- a/dot15d4/src/sync/join.rs
+++ b/dot15d4/src/sync/join.rs
@@ -1,0 +1,133 @@
+#![no_std]
+
+use core::{
+    future::Future,
+    pin::pin,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use super::Either;
+
+/// Combine 2 futures and return if both are ready.
+pub fn join<F1: Future, F2: Future>(
+    f1: F1,
+    f2: F2,
+) -> impl Future<Output = (F1::Output, F2::Output)> {
+    JoinFuture {
+        f1: Either::First(f1),
+        f2: Either::First(f2),
+    }
+}
+
+pub struct JoinFuture<F1: Future, F2: Future> {
+    f1: Either<F1, Option<F1::Output>>,
+    f2: Either<F2, Option<F2::Output>>,
+}
+
+impl<F1, F2> Future for JoinFuture<F1, F2>
+where
+    F1: Future,
+    F2: Future,
+{
+    type Output = (F1::Output, F2::Output);
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Safety: self is not used after this point, so it is not moved
+        let this = unsafe { self.get_unchecked_mut() };
+
+        // Make progress if the task is not yet finished
+        // Safety: this is pinned, so f1 will not be moved either
+        if let Some(res) = unsafe { poll_future(&mut this.f1, cx) } {
+            this.f1 = Either::Second(Some(res));
+        }
+        if let Some(res) = unsafe { poll_future(&mut this.f2, cx) } {
+            this.f2 = Either::Second(Some(res));
+        }
+
+        match (&mut this.f1, &mut this.f2) {
+            (Either::Second(f1 @ Some(_)), Either::Second(f2 @ Some(_))) => {
+                Poll::Ready((f1.take().unwrap(), f2.take().unwrap()))
+            }
+            _ => Poll::Pending,
+        }
+    }
+}
+
+/// # Safety
+/// The future behind the f may not be moved while this function is being executed
+unsafe fn poll_future<F: Future>(
+    f: &mut Either<F, Option<F::Output>>,
+    cx: &mut Context,
+) -> Option<F::Output> {
+    match f {
+        Either::First(f) => match Pin::new_unchecked(f).poll(cx) {
+            Poll::Ready(res) => Some(res),
+            Poll::Pending => None,
+        },
+        Either::Second(rus) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::future::poll_fn;
+    use core::task::Poll;
+
+    use pollster::FutureExt as _;
+
+    use crate::sync::Either;
+
+    use super::join;
+
+    #[test]
+    pub fn test_select_immediate_ready_first() {
+        async {
+            let f1 = poll_fn(|_| Poll::Ready(1));
+            let f2 = poll_fn(|_| Poll::Ready(2));
+
+            assert_eq!(join(f1, f2).await, (1, 2));
+        }
+        .block_on();
+    }
+
+    #[test]
+    pub fn test_select_wait_until_one_finished() {
+        async {
+            let mut counter = 10;
+            let f1 = poll_fn(move |cx| {
+                if counter == 0 {
+                    Poll::Ready(())
+                } else {
+                    counter -= 1;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            });
+            let f2 = poll_fn(|_| Poll::Ready(()));
+
+            assert_eq!(join(f1, f2).await, ((), ()));
+        }
+        .block_on();
+    }
+
+    #[test]
+    pub fn test_select_wait_until_second_finished() {
+        async {
+            let mut counter = 10;
+            let f1 = poll_fn(|_| Poll::Ready(()));
+            let f2 = poll_fn(move |cx| {
+                if counter == 0 {
+                    Poll::Ready(())
+                } else {
+                    counter -= 1;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            });
+
+            assert_eq!(join(f1, f2).await, ((), ()));
+        }
+        .block_on();
+    }
+}

--- a/dot15d4/src/sync/mod.rs
+++ b/dot15d4/src/sync/mod.rs
@@ -1,0 +1,26 @@
+#![no_std]
+//! A handful of executor independent synchronization primitives.
+//! The goal is to provide some synchronization within 1 task between different parts of that task.
+pub(crate) mod channel;
+pub(crate) mod join;
+pub(crate) mod mutex;
+pub(crate) mod select;
+pub(crate) mod yield_now;
+
+/// Type representing 2 possible outcomes/states
+#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(PartialEq)]
+pub enum Either<T, S> {
+    First(T),
+    Second(S),
+}
+
+impl<T, S> Either<T, S> {
+    pub fn is_first(&self) -> bool {
+        matches!(self, Either::First(_))
+    }
+
+    pub fn is_second(&self) -> bool {
+        matches!(self, Either::Second(_))
+    }
+}

--- a/dot15d4/src/sync/mutex.rs
+++ b/dot15d4/src/sync/mutex.rs
@@ -1,0 +1,203 @@
+#![no_std]
+
+use core::cell::RefCell;
+use core::cell::UnsafeCell;
+use core::future::poll_fn;
+use core::future::Future;
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
+use core::pin::pin;
+use core::pin::Pin;
+use core::task::Waker;
+use core::task::{Context, Poll};
+
+struct MutexState {
+    locked: bool,
+    waker: Option<Waker>,
+}
+
+/// A generic mutex that is independent on the underlying async runtime.
+/// The idea is that this is used to synchronize different parts inside 1 single task that may run concurrently through `select`.
+pub struct Mutex<T> {
+    value: UnsafeCell<T>,
+    state: RefCell<MutexState>,
+    _no_send_sync: PhantomData<*mut T>, // Probably not needed as we have `UnsafeCell`
+}
+
+impl<T> Mutex<T> {
+    pub fn new(value: T) -> Self {
+        Mutex {
+            value: UnsafeCell::new(value),
+            state: RefCell::new(MutexState {
+                locked: false,
+                waker: None,
+            }),
+            _no_send_sync: PhantomData,
+        }
+    }
+
+    pub async fn lock(&self) -> MutexGuard<'_, T> {
+        // Wait until we can acquire the lock
+        LockFuture { mutex: self }.await;
+
+        // Now that we have acquired the lock, we can return the mutex
+        MutexGuard { mutex: self }
+    }
+
+    /// Get access to the protected value inside the mutex. This is similar to
+    /// the Mutex::get_mut in std.
+    pub fn get_mut(&mut self) -> &mut T {
+        // Safety: &mut gives us exclusive access to T
+        self.value.get_mut()
+    }
+}
+
+/// Represesnts current exclusive access to the resource protected by a mutex
+pub struct MutexGuard<'a, T> {
+    mutex: &'a Mutex<T>,
+}
+
+impl<'a, T> Deref for MutexGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        /// Safety: Only one mutex can exist at a time
+        unsafe {
+            &*self.mutex.value.get()
+        }
+    }
+}
+
+impl<'a, T> DerefMut for MutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        /// Safety: Only one mutex can exist at a time
+        unsafe {
+            &mut *self.mutex.value.get()
+        }
+    }
+}
+
+impl<'a, T> Drop for MutexGuard<'a, T> {
+    fn drop(&mut self) {
+        let mut mutex_state = self.mutex.state.borrow_mut();
+
+        // Release the lock
+        mutex_state.locked = false;
+
+        // Call the waker if needed
+        if let Some(waker) = mutex_state.waker.take() {
+            waker.wake()
+        }
+    }
+}
+
+struct LockFuture<'a, T> {
+    mutex: &'a Mutex<T>,
+}
+
+impl<'a, T> Future for LockFuture<'a, T> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut mutex_state = self.mutex.state.borrow_mut();
+        if mutex_state.locked {
+            // Mutex is locked here, wake the previous task, so it can make progress and we do not have to remember it
+            let new_waker = cx.waker();
+            match &mut mutex_state.waker {
+                // We already have the same waker stored, do not wake
+                Some(waker) if waker.will_wake(new_waker) => {
+                    waker.clone_from(new_waker);
+                }
+                // New waker, wake the previous and store current
+                waker @ Some(_) => {
+                    waker.take().unwrap().wake();
+                    *waker = Some(new_waker.clone());
+                }
+                // No waker yet, store the new one
+                waker @ None => *waker = Some(new_waker.clone()),
+            };
+
+            // Mutex is locked, keep waiting
+            Poll::Pending
+        } else {
+            // Mutex is unlocked, lock it
+            mutex_state.locked = true;
+
+            Poll::Ready(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pollster::FutureExt as _;
+
+    use crate::sync::{join::join, select::select};
+
+    use super::Mutex;
+
+    #[test]
+    pub fn test_mutex_no_concurrency() {
+        async {
+            let mut mutex = Mutex::new(0usize);
+            {
+                let mut guard = mutex.lock().await;
+                *guard += 1;
+                assert_eq!(*guard, 1, "The guard should be readable");
+            }
+
+            assert_eq!(
+                *mutex.get_mut(),
+                1,
+                "The internal mutex should have been updated"
+            )
+        }
+        .block_on()
+    }
+
+    #[test]
+    pub fn test_mutex_select_concurrency() {
+        async {
+            let mut mutex = Mutex::new(0usize);
+            for _ in 0..100 {
+                select(
+                    async {
+                        let mut guard = mutex.lock().await;
+                        *guard += 1;
+                    },
+                    async {
+                        let mut guard = mutex.lock().await;
+                        *guard += 1;
+                    },
+                )
+                .await;
+            }
+
+            assert_eq!(*mutex.get_mut(), 100);
+        }
+        .block_on()
+    }
+
+    #[test]
+    pub fn test_mutex_join_concurrency() {
+        async {
+            let mut mutex = Mutex::new(0usize);
+            for _ in 0..100 {
+                join(
+                    async {
+                        let mut guard = mutex.lock().await;
+                        *guard += 1;
+                    },
+                    async {
+                        let mut guard = mutex.lock().await;
+                        *guard += 1;
+                    },
+                )
+                .await;
+            }
+
+            assert_eq!(*mutex.get_mut(), 200);
+        }
+        .block_on()
+    }
+}

--- a/dot15d4/src/sync/select.rs
+++ b/dot15d4/src/sync/select.rs
@@ -1,0 +1,118 @@
+#![no_std]
+
+use super::mutex::MutexGuard;
+use super::Either;
+use core::{
+    future::Future,
+    pin::pin,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// Combines 2 futures and returns the result of the first future to terminate.
+/// The other one gets canceled/dropped
+pub fn select<F1: Future, F2: Future>(
+    f1: F1,
+    f2: F2,
+) -> impl Future<Output = Either<F1::Output, F2::Output>> {
+    SelectFuture { f1, f2 }
+}
+
+pub struct SelectFuture<F1, F2> {
+    f1: F1,
+    f2: F2,
+}
+
+impl<F1, F2> Future for SelectFuture<F1, F2>
+where
+    F1: Future,
+    F2: Future,
+{
+    type Output = Either<F1::Output, F2::Output>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = unsafe { self.get_unchecked_mut() };
+        if let Poll::Ready(res) = unsafe { Pin::new_unchecked(&mut this.f1) }.poll(cx) {
+            return Poll::Ready(Either::First(res));
+        }
+        if let Poll::Ready(res) = unsafe { Pin::new_unchecked(&mut this.f2) }.poll(cx) {
+            return Poll::Ready(Either::Second(res));
+        }
+
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::future::poll_fn;
+    use core::task::Poll;
+
+    use pollster::FutureExt as _;
+
+    use crate::sync::Either;
+
+    use super::select;
+
+    #[test]
+    pub fn test_select_immediate_ready_first() {
+        async {
+            let f1 = poll_fn(|_| Poll::Ready(1));
+            let f2 = poll_fn(|_| Poll::Ready(2));
+
+            assert_eq!(select(f1, f2).await, Either::First(1));
+        }
+        .block_on();
+    }
+
+    #[test]
+    pub fn test_select_immediate_ready_second() {
+        async {
+            let f1 = poll_fn(|_| Poll::<()>::Pending);
+            let f2 = poll_fn(|_| Poll::Ready(2));
+
+            assert_eq!(select(f1, f2).await, Either::Second(2));
+        }
+        .block_on();
+    }
+
+    #[test]
+    pub fn test_select_wait_until_one_finished() {
+        async {
+            let mut counter = 10;
+            let f1 = poll_fn(move |cx| {
+                if counter == 0 {
+                    Poll::Ready(())
+                } else {
+                    counter -= 1;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            });
+            let f2 = poll_fn(|_| Poll::<()>::Pending);
+
+            assert_eq!(select(f1, f2).await, Either::First(()));
+        }
+        .block_on();
+    }
+
+    #[test]
+    pub fn test_select_wait_until_second_finished() {
+        async {
+            let mut counter = 10;
+            let f1 = poll_fn(|_| Poll::<()>::Pending);
+            let f2 = poll_fn(move |cx| {
+                if counter == 0 {
+                    Poll::Ready(())
+                } else {
+                    counter -= 1;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            });
+
+            assert_eq!(select(f1, f2).await, Either::Second(()));
+        }
+        .block_on();
+    }
+}

--- a/dot15d4/src/sync/yield_now.rs
+++ b/dot15d4/src/sync/yield_now.rs
@@ -1,0 +1,38 @@
+#![no_std]
+
+use core::{future::poll_fn, task::Poll};
+
+/// Simple function that makes the current task yield immediatly, such that
+/// other tasks can have the opportunity to make progress
+pub async fn yield_now() {
+    let mut has_yielded = false;
+    poll_fn(move |cx| {
+        if has_yielded {
+            Poll::Ready(())
+        } else {
+            cx.waker().wake_by_ref(); // Make sure we get called again soon
+            has_yielded = true;
+            Poll::Pending
+        }
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread::yield_now;
+
+    use pollster::FutureExt;
+
+    #[test]
+    pub fn test_yield_finishes() {
+        assert!(
+            async {
+                yield_now();
+                true
+            }
+            .block_on(),
+            "Yield should fininsh"
+        );
+    }
+}


### PR DESCRIPTION
When implementing protocols like CSMA, it is often necessary to communicate between different parts of the implementation. This PR is an initial version of executor independent synchronization for internal use only.

The goal of this PR is to provide some concurrency primitives that are valid in 1 task. This would allow concurrency to work in between different parts that are multiplexed with for example a `select` or `join` operation.

Parts of this PR:
* `select`
* `join`
* `Mutex`
* Signal/Channel
* `yield_now`