### PR TITLE
Make CSMA config `non_exhaustive`

### DIFF
--- a/dot15d4/src/csma/mod.rs
+++ b/dot15d4/src/csma/mod.rs
@@ -38,6 +38,7 @@ enum TransmissionTaskError<D: core::fmt::Debug> {
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[non_exhaustive]
 pub struct CsmaConfig {
     /// All to be transmitted frames will get the ack_request flag set if they
     /// are unicast and a data frame


### PR DESCRIPTION
This PR makes the CSMA config non exhaustive. This is to make it possible to later add new configuration options without making it a breaking change.