### PR TITLE
Fix math

### DIFF
--- a/dot15d4/src/csma/mod.rs
+++ b/dot15d4/src/csma/mod.rs
@@ -413,10 +413,10 @@ where
                         .await;
 
                     // We expect an ACK to come back AIFS + time for an ACK to travel + SIFS (guard)
-                    // An ACK is 3 bytes long and should take around 24 us at 250kbps to get back
+                    // An ACK is 3 bytes + 6 bytes (PHY header) long and should take around 288us at 250kbps to get back
                     let delay = ACKNOWLEDGEMENT_INTERFRAME_SPACING
                         + MAC_SIFT_PERIOD
-                        + Duration::from_us(24);
+                        + Duration::from_us(288);
                     match select::select(
                         Self::wait_for_valid_ack(
                             &mut *radio_guard.unwrap(),


### PR DESCRIPTION
There was a small mistake in the calculation for the time to transmit an ACK. This should not impact the working of CSMA too much, but makes things a bit more correct.