### PR TITLE
Configurable constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ Add this to your `Cargo.toml`:
 dot15d4 = "0.1.0"
 ```
 
+### Configurable features 
+
+* `std`: Enables `std` only features
+* `log`: Use the `log` crate for structured logging
+* `defmt`: Use the `defmt` crate for structured logging
+
+### Configurable environment variables
+
+* `DOT15D4_MAC_MIN_BE` (default: 0): Minimum backoff exponent used in `CSMA`
+* `DOT15D4_MAC_MAX_BE` (default: 8): Maximum backoff exponent used in `CSMA`
+* `DOT15D4_MAC_UNIT_BACKOFF_DURATION` (default: 320us): The time of one backoff period 
+* `DOT15D4_MAC_MAX_FRAME_RETRIES` (default: 3): Maximum CCA/ACK rounds
+* `DOT15D4_MAC_AIFS_PERIOD` (default: 1ms): The minimal time for the receiving end to go from transmitting to receiving mode when sending an ACK
+* `DOT15D4_MAC_SIFS_PERIOD` (default: 1ms): The inter-frame spacing time for short frames
+* `DOT15D4_MAC_LIFS_PERIOD` (default: 10ms): The inter-frame spacing time for long frames
+
 For more information, see the [API documentation](https://docs.rs/dot15d4).
 
 ## dot15d4 as a binary

--- a/dot15d4/build.rs
+++ b/dot15d4/build.rs
@@ -1,0 +1,66 @@
+use std::collections::HashMap;
+use std::env;
+use std::fmt::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // (Variable, Type, Default value)
+    let mut configs: HashMap<&str, (&str, &str)> = HashMap::from([
+        ("MAC_MIN_BE", ("u16", "0")),
+        ("MAC_MAX_BE", ("u16", "8")),
+        ("MAC_MAX_CSMA_BACKOFFS", ("u16", "16")),
+        (
+            "MAC_UNIT_BACKOFF_DURATION",
+            (
+                "Duration",
+                "Duration::from_us((UNIT_BACKOFF_PERIOD * SYMBOL_RATE_INV_US) as i64)",
+            ),
+        ),
+        ("MAC_MAX_FRAME_RETIES", ("u16", "3")),
+        (
+            "CSMA_INTER_FRAME_TIME",
+            ("Duration", "Duration::from_us(1000)"),
+        ),
+        ("MAC_AIFS_PERIOD", ("Duration", "Duration::from_us(1000)")),
+        ("MAC_SIFS_PERIOD", ("Duration", "Duration::from_us(1000)")),
+        ("MAC_LIFS_PERIOD", ("Duration", "Duration::from_us(10_000)")),
+    ]);
+
+    // Make sure we get rerun if needed
+    println!("cargo:rerun-if-changed=build.rs");
+    for name in configs.keys() {
+        println!("cargo:rerun-if-env-changed=DOT15D4_{name}");
+    }
+
+    // Collect environment variables
+    let mut data = String::new();
+    // Write preamble
+    writeln!(data, "use crate::time::Duration;").unwrap();
+    writeln!(
+        data,
+        "use crate::csma::{{SYMBOL_RATE_INV_US, UNIT_BACKOFF_PERIOD}};"
+    )
+    .unwrap();
+
+    for (var, value) in std::env::vars() {
+        if let Some(name) = var.strip_prefix("DOT15D4_") {
+            // discard from hashmap as a way of consuming the setting
+            let Some((ty, _)) = configs.remove_entry(name) else {
+                panic!("Wrong configuration name {name}");
+            };
+
+            // write to file
+            writeln!(data, "pub const {name}: {ty} = {value};").unwrap();
+        }
+    }
+
+    // Take the remaining configs and write the default value to the file
+    for (name, (ty, value)) in configs.iter() {
+        writeln!(data, "pub const {name}: {ty} = {value};").unwrap();
+    }
+
+    // Now that we have the code of the configuration, actually write it to a file
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let out_file = out_dir.join("config.rs");
+    std::fs::write(out_file, data).unwrap();
+}

--- a/dot15d4/src/csma/mod.rs
+++ b/dot15d4/src/csma/mod.rs
@@ -459,7 +459,7 @@ where
                     self.driver.error(driver::Error::AckFailed).await;
                     break 'ack;
                 } else {
-                    self.driver.error(driver::Error::AckBackoff(i_ack)).await;
+                    self.driver.error(driver::Error::AckRetry(i_ack)).await;
                 }
             }
         }
@@ -921,7 +921,7 @@ pub mod tests {
             assert!(
                 matches!(
                     monitor.errors.receive().await,
-                    driver::Error::AckFailed | driver::Error::AckBackoff(_), // ACK has failed, so we propagate an error up
+                    driver::Error::AckFailed | driver::Error::AckRetry(_), // ACK has failed, so we propagate an error up
                 ),
                 "Packet transmission should fail due to ACK not received after to many times"
             );

--- a/dot15d4/src/csma/mod.rs
+++ b/dot15d4/src/csma/mod.rs
@@ -414,9 +414,9 @@ where
                         .await;
 
                     // We expect an ACK to come back AIFS + time for an ACK to travel + SIFS (guard)
-                    // An ACK is 3 bytes + 6 bytes (PHY header) long 
+                    // An ACK is 3 bytes + 6 bytes (PHY header) long
                     // and should take around 288us at 250kbps to get back
-                    let delay = MAC_AIFS_PERIOD + MAC_SIFT_PERIOD + Duration::from_us(288);
+                    let delay = MAC_AIFS_PERIOD + MAC_SIFS_PERIOD + Duration::from_us(288);
 
                     match select::select(
                         Self::wait_for_valid_ack(

--- a/dot15d4/src/csma/mod.rs
+++ b/dot15d4/src/csma/mod.rs
@@ -248,7 +248,7 @@ where
                             // guaranteed to be exact. This is due to how Rust futures
                             // work and the timer becomes an 'at least this waiting time'
                             // The goal is to transmit an ACK between 1ms and 2ms.
-                            let delay = ACKNOWLEDGEMENT_INTERFRAME_SPACING / 2;
+                            let delay = MAC_AIFS_PERIOD / 2;
                             timer.delay_us(delay.as_us() as u32).await;
 
                             // We already have the lock on the radio, so start transmitting and do not
@@ -414,9 +414,7 @@ where
 
                     // We expect an ACK to come back AIFS + time for an ACK to travel + SIFS (guard)
                     // An ACK is 3 bytes long and should take around 24 us at 250kbps to get back
-                    let delay = ACKNOWLEDGEMENT_INTERFRAME_SPACING
-                        + MAC_SIFT_PERIOD
-                        + Duration::from_us(24);
+                    let delay = MAC_AIFS_PERIOD + MAC_SIFS_PERIOD + Duration::from_us(24);
                     match select::select(
                         Self::wait_for_valid_ack(
                             &mut *radio_guard.unwrap(),
@@ -449,7 +447,7 @@ where
                 radio_guard = None;
 
                 // Wait for SIFS here
-                let delay = MAC_SIFT_PERIOD.max(Duration::from_us(
+                let delay = MAC_SIFS_PERIOD.max(Duration::from_us(
                     (TURNAROUND_TIME * SYMBOL_RATE_INV_US) as i64,
                 ));
                 timer.delay_us(delay.as_us() as u32).await;

--- a/dot15d4/src/csma/user_configurable_constants.rs
+++ b/dot15d4/src/csma/user_configurable_constants.rs
@@ -1,19 +1,29 @@
-#![allow(dead_code)]
+/// Export all user definable constants
+pub use constants::*;
 
-use crate::time::Duration;
+#[cfg(test)]
+mod constants {
+    #![allow(dead_code)]
+    use crate::csma::{SYMBOL_RATE_INV_US, UNIT_BACKOFF_PERIOD};
+    use crate::time::Duration;
 
-use super::constants::{SYMBOL_RATE_INV_US, UNIT_BACKOFF_PERIOD};
+    // XXX These are just random numbers I picked by fair dice roll; what should
+    // they be?
+    pub const MAC_MIN_BE: u16 = 0;
+    pub const MAC_MAX_BE: u16 = 8;
+    pub const MAC_MAX_CSMA_BACKOFFS: u16 = 16;
+    pub const MAC_UNIT_BACKOFF_DURATION: Duration =
+        Duration::from_us((UNIT_BACKOFF_PERIOD * SYMBOL_RATE_INV_US) as i64);
+    pub const MAC_MAX_FRAME_RETIES: u16 = 3; // 0-7
+    pub const MAC_INTER_FRAME_TIME: Duration = Duration::from_us(1000); // TODO: XXX
+    /// AIFS=1ms, for SUN PHY, LECIM PHY, TVWS PHY
+    pub const MAC_AIFS_PERIOD: Duration = Duration::from_us(1000);
+    pub const MAC_SIFS_PERIOD: Duration = Duration::from_us(1000); // TODO: SIFS=XXX
+    pub const MAC_LIFS_PERIOD: Duration = Duration::from_us(10_000); // TODO: LIFS=XXX
+}
 
-// XXX These are just random numbers I picked by fair dice roll; what should
-// they be?
-pub const MAC_MIN_BE: u16 = 0;
-pub const MAC_MAX_BE: u16 = 8;
-pub const MAC_MAX_CSMA_BACKOFFS: u16 = 16;
-pub const MAC_UNIT_BACKOFF_DURATION: Duration =
-    Duration::from_us((UNIT_BACKOFF_PERIOD * SYMBOL_RATE_INV_US) as i64);
-pub const MAC_MAX_FRAME_RETIES: u16 = 3; // 0-7
-pub const _MAC_INTER_FRAME_TIME: Duration = Duration::from_us(1000); // TODO: XXX
-/// AIFS=1ms, for SUN PHY, LECIM PHY, TVWS PHY
-pub const ACKNOWLEDGEMENT_INTERFRAME_SPACING: Duration = Duration::from_us(1000);
-pub const MAC_SIFT_PERIOD: Duration = Duration::from_us(1000); // TODO: SIFS=XXX
-pub const MAC_LIFS_PERIOD: Duration = Duration::from_us(10_000); // TODO: LIFS=XXX
+#[cfg(not(test))]
+mod constants {
+    #![allow(unused)]
+    include!(concat!(env!("OUT_DIR"), "/config.rs"));
+}

--- a/dot15d4/src/phy/driver.rs
+++ b/dot15d4/src/phy/driver.rs
@@ -8,7 +8,7 @@ pub enum Error {
     /// Cca failed after to many fallbacks
     CcaFailed,
     /// Ack failed, resulting in a retry later (nth try)
-    AckBackoff(u16),
+    AckRetry(u16),
     /// Ack failed, after to many retransmissions
     AckFailed,
     /// The buffer did not follow the correct device structure

--- a/dot15d4/src/phy/driver.rs
+++ b/dot15d4/src/phy/driver.rs
@@ -3,8 +3,12 @@ use core::future::Future;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Error {
+    /// Cca failed, resulting in a backoff (nth try)
+    CcaBackoff(u16),
     /// Cca failed after to many fallbacks
     CcaFailed,
+    /// Ack failed, resulting in a retry later (nth try)
+    AckBackoff(u16),
     /// Ack failed, after to many retransmissions
     AckFailed,
     /// The buffer did not follow the correct device structure


### PR DESCRIPTION
This PR adds the ability to configure the user configurable constants through environment variables. This makes it easier to change them for an end-user.

Additionally, documentation in the README has been added with a short description about the meaning of all the environment variables.

Lastly, to help with better keeping track of what is happening, more fine-grained errors are added about the CCA backoff and ACK retries.