### PR TITLE
feat: Initial implementation of PAN IDs

### DIFF
--- a/dot15d4/build.rs
+++ b/dot15d4/build.rs
@@ -47,7 +47,7 @@ fn main() {
     for (var, value) in std::env::vars() {
         if let Some(name) = var.strip_prefix("DOT15D4_") {
             // discard from hashmap as a way of consuming the setting
-            let Some((ty, _)) = configs.remove_entry(name) else {
+            let Some((_, (ty, _))) = configs.remove_entry(name) else {
                 panic!("Wrong configuration name {name}");
             };
 

--- a/dot15d4/build.rs
+++ b/dot15d4/build.rs
@@ -24,6 +24,8 @@ fn main() {
         ("MAC_AIFS_PERIOD", ("Duration", "Duration::from_us(1000)")),
         ("MAC_SIFS_PERIOD", ("Duration", "Duration::from_us(1000)")),
         ("MAC_LIFS_PERIOD", ("Duration", "Duration::from_us(10_000)")),
+        ("MAC_PAN_ID", ("u16", "0xffff")),
+        ("MAC_IMPLICIT_BROADCAST", ("bool", "false")),
     ]);
 
     // Make sure we get rerun if needed

--- a/dot15d4/src/csma/constants.rs
+++ b/dot15d4/src/csma/constants.rs
@@ -9,6 +9,8 @@ pub const TURNAROUND_TIME: u32 = 12;
 /// The time required to perform CCA detection in symbol periods.
 pub const CCA_TIME: u32 = 8;
 
+pub const BROADCAST_PAN_ID: u16 = 0xffff;
+
 // /// The delay between the start of the SFD and the LEIP, as described in
 // /// 18.6.
 // const A_LEIP_DELAY_TIME: u32 = 0.815 ms

--- a/dot15d4/src/csma/user_configurable_constants.rs
+++ b/dot15d4/src/csma/user_configurable_constants.rs
@@ -20,6 +20,9 @@ mod constants {
     pub const MAC_AIFS_PERIOD: Duration = Duration::from_us(1000);
     pub const MAC_SIFS_PERIOD: Duration = Duration::from_us(1000); // TODO: SIFS=XXX
     pub const MAC_LIFS_PERIOD: Duration = Duration::from_us(10_000); // TODO: LIFS=XXX
+                                                                     // PAN Id
+    pub const MAC_PAN_ID: u16 = 0xffff;
+    pub const MAC_IMPLICIT_BROADCAST: bool = false;
 }
 
 #[cfg(not(test))]


### PR DESCRIPTION
Implemented partial rejection rules of IEEE 802.15.4 - 2015 standard p101-102

These include:
- [x] The Frame Type field shall not contain a reserved frame type.
- [x] The Frame Version field shall not contain a reserved value.  
- [x] If a destination PAN ID is included in the frame, it shall match `macPanId` or shall be the broadcast PAN ID.
- [ ] The Destination Address field shall satisfy one of the following conditions:  
  - [x] A short destination address is included in the frame and it matches either `macShortAddress` or the broadcast address.  
  - [ ] An extended destination address is included in the frame and matches either
    - [x] `macExtendedAddress` or,
    - [ ] if `macGroupRxMode` is set to TRUE, an EUI-64 group address, as defined in IEEE Std 802. 
  - [x] The Destination Address field and the Destination PAN ID field are not included in the frame and `macImplicitBroadcast` is TRUE. 
  - [ ] The device is the PAN coordinator, only source addressing fields are included in a Data frame or MAC command and the source PAN ID matches `macPanId`.  
  - [ ] The device is the PAN coordinator, only source addressing fields are included in a Multipurpose frame and the destination PAN ID matches `macPanId`.  
- [ ] If the frame type indicates that the frame is a Beacon frame, the source PAN ID shall match `macPanId` unless `macPanId` is equal to the broadcast PAN ID, in which case the Beacon frame shall be accepted regardless of the source PAN ID.

Some of the above are not part of this PR, as full PAN coordinators have not yet been implemented. Neither is the logic for `macGroupRXMode`.

While adding these changes, a fix to some of the tests is added to prevent an assertion in a `drop` while unwinding from a previous failed assertion. This originally caused the test harness to completely abort. With these changes, the test harness does not completely abort and shows a list of the successful and failed tests.