### PR TITLE
Fix panic when different pan IDs

### DIFF
--- a/dot15d4-frame/src/repr/builder.rs
+++ b/dot15d4-frame/src/repr/builder.rs
@@ -328,8 +328,10 @@ impl<'p, T> FrameBuilder<'p, T> {
                 addr.src_pan_id,
             ) {
                 (Some(_), Some(_), Some(dst_pan_id), Some(src_pan_id)) => {
-                    self.frame.frame_control.pan_id_compression = dst_pan_id == src_pan_id;
-                    addr.src_pan_id = None;
+                    if dst_pan_id == src_pan_id {
+                        self.frame.frame_control.pan_id_compression = true;
+                        addr.src_pan_id = None;
+                    }
                 }
                 (Some(_), None, Some(_), _) => {
                     self.frame.frame_control.pan_id_compression = false;

--- a/dot15d4-frame/src/tests.rs
+++ b/dot15d4-frame/src/tests.rs
@@ -339,3 +339,26 @@ fn emit_enhanced_beacon() {
         ],
     );
 }
+
+/// https://github.com/thvdveld/dot15d4/issues/29
+/// Setting `dst_pan_id` to a different value than `src_pan_id` made the `emit` function panic.
+#[test]
+fn issue29() {
+    let frame = FrameBuilder::new_data(&[0x2b, 0x00, 0x00, 0x00])
+        .set_sequence_number(1)
+        .set_dst_pan_id(0xabce)
+        .set_dst_address(Address::Short([0x02, 0x04]))
+        .set_src_pan_id(0xabcd)
+        .set_src_address(Address::Extended([
+            0x00, 0x12, 0x4b, 0x00, 0x14, 0xb5, 0xd9, 0xc7,
+        ]))
+        .finalize()
+        .unwrap();
+
+    let mut buffer = vec![0; frame.buffer_len()];
+
+    frame.emit(&mut Frame::new_unchecked(&mut buffer[..]));
+
+    println!("{:?}", frame);
+    println!("packet = {:#04X?}", buffer);
+}


### PR DESCRIPTION
When the PAN IDs are equal, then PAN ID compression is used, removing the source PAN ID from the frame. The same behaviour was observed when the PAN IDs were different, which is incorrect. This commit fixes the issue by only compressing the source PAN ID when the PAN IDs are equal.

Fixes #29.