### PR TITLE
Fix typos

### DIFF
--- a/dot15d4-frame/src/frames/beacon.rs
+++ b/dot15d4-frame/src/frames/beacon.rs
@@ -175,7 +175,7 @@ impl From<BeaconOrder> for u8 {
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[repr(u8)]
-///  The lenght of the active portion of the superframe.
+///  The length of the active portion of the superframe.
 pub enum SuperframeOrder {
     /// The superframe duration is calculated with:
     /// `base_super_frame_duration * 2^{superframe_order}`

--- a/dot15d4-frame/src/ie/nested.rs
+++ b/dot15d4-frame/src/ie/nested.rs
@@ -861,7 +861,7 @@ impl<T: AsRef<[u8]>> TschSlotframeAndLink<T> {
             return false;
         }
 
-        let _number_of_slot_frames = self.number_of_slot_frames() as usize;
+        let _number_of_slotframes = self.number_of_slotframes() as usize;
         let slotframe_descriptors_len =
             self.slotframe_descriptors().map(|d| d.len()).sum::<usize>();
 
@@ -875,14 +875,14 @@ impl<T: AsRef<[u8]>> TschSlotframeAndLink<T> {
     }
 
     /// Return the number of slotframes field.
-    pub fn number_of_slot_frames(&self) -> u8 {
+    pub fn number_of_slotframes(&self) -> u8 {
         self.data.as_ref()[0]
     }
 
     /// Returns an [`Iterator`] over the [`SlotframeDescriptor`]s.
     pub fn slotframe_descriptors(&self) -> SlotframeDescriptorIterator {
         SlotframeDescriptorIterator::new(
-            self.number_of_slot_frames() as usize,
+            self.number_of_slotframes() as usize,
             &self.data.as_ref()[1..],
         )
     }
@@ -890,14 +890,14 @@ impl<T: AsRef<[u8]>> TschSlotframeAndLink<T> {
 
 impl<T: AsRef<[u8]> + AsMut<[u8]>> TschSlotframeAndLink<T> {
     /// Set the number of slotframes field.
-    pub fn set_number_of_slot_frames(&mut self, number_of_slot_frames: u8) {
-        self.data.as_mut()[0] = number_of_slot_frames;
+    pub fn set_number_of_slotframes(&mut self, number_of_slotframes: u8) {
+        self.data.as_mut()[0] = number_of_slotframes;
     }
 }
 
 impl<T: AsRef<[u8]>> core::fmt::Display for TschSlotframeAndLink<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "#slot frames: {}", self.number_of_slot_frames())
+        write!(f, "#slotframes: {}", self.number_of_slotframes())
     }
 }
 

--- a/dot15d4-frame/src/repr/ie/nested.rs
+++ b/dot15d4-frame/src/repr/ie/nested.rs
@@ -146,14 +146,14 @@ impl TschSynchronizationRepr {
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct TschSlotframeAndLinkRepr {
     /// The number of slotframes.
-    pub number_of_slot_frames: u8,
+    pub number_of_slotframes: u8,
 }
 
 impl TschSlotframeAndLinkRepr {
     /// Parse a TSCH Slotframe and Link Information Element.
     pub fn parse(ie: &TschSlotframeAndLink<&[u8]>) -> Self {
         Self {
-            number_of_slot_frames: ie.number_of_slot_frames(),
+            number_of_slotframes: ie.number_of_slotframes(),
         }
     }
 
@@ -165,7 +165,7 @@ impl TschSlotframeAndLinkRepr {
 
     /// Emit the TSCH Slotframe and Link Information Element into a buffer.
     pub fn emit(&self, ie: &mut TschSlotframeAndLink<&mut [u8]>) {
-        ie.set_number_of_slot_frames(self.number_of_slot_frames);
+        ie.set_number_of_slotframes(self.number_of_slotframes);
     }
 }
 

--- a/dot15d4-frame/src/tests/mod.rs
+++ b/dot15d4-frame/src/tests/mod.rs
@@ -145,7 +145,7 @@ fn emit_enhanced_beacon() {
                         hopping_sequence_id: 0,
                     }),
                     NestedInformationElementRepr::TschSlotframeAndLink(TschSlotframeAndLinkRepr {
-                        number_of_slot_frames: 0,
+                        number_of_slotframes: 0,
                     }),
                 ])),
             ]),

--- a/dot15d4-frame/src/tests/parsing/beacon.rs
+++ b/dot15d4-frame/src/tests/parsing/beacon.rs
@@ -180,7 +180,7 @@ fn parse_enhanced_beacon() {
         },
         |slotframe| {
             test!(
-                slotframe.number_of_slot_frames() => 0,
+                slotframe.number_of_slotframes() => 0,
             );
         }
     );

--- a/dot15d4/src/phy/radio/futures.rs
+++ b/dot15d4/src/phy/radio/futures.rs
@@ -37,7 +37,7 @@ impl<F: FnOnce()> Drop for OnDrop<F> {
 
 /// Convenience Future around transmitting through the radio. This future first
 /// prepares the radio, then transmits before succeeding. This future, upon
-/// canceling, stops the radio from transmitting and puts the radio in an IDLE
+/// cancelling, stops the radio from transmitting and puts the radio in an IDLE
 /// state.
 #[allow(clippy::await_holding_refcell_ref)]
 pub async fn transmit<'task, T: AsMut<[u8]>, R: Radio>(
@@ -61,7 +61,7 @@ pub async fn transmit<'task, T: AsMut<[u8]>, R: Radio>(
 
 /// Convenience Future around receiving through the radio. This future first
 /// prepares the radio, then receives before succeeding. This future, upon
-/// canceling, stops the radio from receiving and puts the radio in an IDLE
+/// cancelling, stops the radio from receiving and puts the radio in an IDLE
 /// state.
 #[allow(clippy::await_holding_refcell_ref)]
 pub async fn receive<'task, R: Radio>(


### PR DESCRIPTION
This PR fix several typos and rename all occurence of "slot frame" to "slotframe" in code and comments, as described in standard.