### PR TITLE
Specify end of buffer slice for NestedInformationElement

### DIFF
--- a/dot15d4-frame/src/repr/ie/payloads.rs
+++ b/dot15d4-frame/src/repr/ie/payloads.rs
@@ -91,7 +91,7 @@ impl PayloadInformationElementRepr {
                 let mut offset = 0;
                 for ie in nested_ies.iter() {
                     ie.emit(&mut NestedInformationElement::new_unchecked(
-                        &mut buffer[offset..],
+                        &mut buffer[offset..][..ie.buffer_len()],
                     ));
                     offset += ie.buffer_len();
                 }


### PR DESCRIPTION
This PR delimits the end of the slice of a buffer representing a Nested Information Element.