### PR TITLE
perf: reorder SeqNrRepr to reduce size of SeqNrRepr::length

### DIFF
--- a/dot15d4-frame/src/repr/seq_nr.rs
+++ b/dot15d4-frame/src/repr/seq_nr.rs
@@ -1,16 +1,16 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum SeqNrRepr {
-    /// A sequence number is present in the frame.
-    Yes,
     /// The sequence number is suppressed.
     No,
+    /// A sequence number is present in the frame.
+    Yes,
 } // 1 byte
 
 impl SeqNrRepr {
     pub const fn length(&self) -> u16 {
         match self {
-            SeqNrRepr::Yes => 1,
             SeqNrRepr::No => 0,
+            SeqNrRepr::Yes => 1,
         }
     }
 }


### PR DESCRIPTION
Since `SeqNrRepr::No` returns a length of 0, it is more efficient to put it as the first variant in the enum. This removes 3 instructions from the `length` method (for thumbv7em-none-eabi target).

Assembly before:
```asm
dot15d4_frame::repr::seq_nr::SeqNrRepr::length:
	push {r7, lr}
	mov r7, sp
	ldrb r0, [r0]
	movs r1, #1
	bic.w r0, r1, r0
	pop {r7, pc}
```

Assembly after:
```asm
dot15d4_frame::repr::seq_nr::SeqNrRepr::length:
	push {r7, lr}
	mov r7, sp
	ldrb r0, [r0]
	pop {r7, pc}
```